### PR TITLE
feat: merge scw and env profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ The official documentation is available at https://developers.google.com/tink.
 2. Check the [example](./integration/scwkms/scw_kms_client_test.go) to use the
    extension. Make sure to replace the client fields with your own
    configuration.
+3. Rather than configuring the provider in-app, you can also use Scaleway's
+   configuration file and environment variables. Check [Scaleway's configuration
+   documentation](https://github.com/scaleway/scaleway-cli/blob/master/docs/commands/config.md)
+   for more details.

--- a/integration/scwkms/scw_kms_client.go
+++ b/integration/scwkms/scw_kms_client.go
@@ -27,7 +27,21 @@ type scwClient struct {
 var _ registry.KMSClient = (*scwClient)(nil)
 
 func NewClient(uriPrefix string) (registry.KMSClient, error) {
-	return NewClientWithOptions(uriPrefix, scw.WithEnv())
+	config, err := scw.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	activeProfile, err := config.GetActiveProfile()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClientWithOptions(
+		uriPrefix,
+		scw.WithProfile(activeProfile),
+		scw.WithEnv(),
+	)
 }
 
 func NewClientWithOptions(uriPrefix string, opts ...scw.ClientOption) (registry.KMSClient, error) {


### PR DESCRIPTION
This PR changes the default config in `NewClient(...)`. It now uses the same config as [scaleway-cli](https://github.com/scaleway/scaleway-cli) and merges it with environment variables. Environment variables takes precedence.